### PR TITLE
Enhance city validation in weather endpoint

### DIFF
--- a/middlewares/validation.js
+++ b/middlewares/validation.js
@@ -1,7 +1,15 @@
 const { check, validationResult } = require('express-validator');
 
 const validateWeatherRequest = [
-    check('city').trim().escape().not().isEmpty().withMessage('City is required'),
+    // Ensure the city parameter is a non-empty string containing only alphabetic characters, spaces, hyphens, and apostrophes.
+    check('city')
+        .trim()
+        .escape()
+        .not()
+        .isEmpty()
+        .withMessage('City is required')
+        .matches(/^[a-zA-Z\s'-]+$/)
+        .withMessage('City name must contain only alphabetic characters, spaces, hyphens, and apostrophes'),
     (req, res, next) => {
         const errors = validationResult(req);
         if (!errors.isEmpty()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.7.2",
         "cors": "^2.8.5",
         "express": "^4.19.2",
+        "express-validator": "^7.1.0",
         "helmet": "^7.1.0",
         "joi": "^17.13.3",
         "supertest": "^7.0.0",
@@ -454,6 +455,18 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.1.0.tgz",
+      "integrity": "sha512-ePn6NXjHRZiZkwTiU1Rl2hy6aUqmi6Cb4/s8sfUsKH7j2yYl9azSpl8xEHcOj1grzzQ+UBEoLWtE1s6FDxW++g==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -730,6 +743,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "axios": "^1.7.2",
     "cors": "^2.8.5",
     "express": "^4.19.2",
+    "express-validator": "^7.1.0",
     "helmet": "^7.1.0",
     "joi": "^17.13.3",
     "supertest": "^7.0.0",


### PR DESCRIPTION
city names can be quite diverse and there's no standard format to validate against (e.g., some city names contain spaces, hyphens, etc.).
'.matches(/^[a-zA-Z\s'-]+$/).withMessage('City name must contain only alphabetic characters, spaces, hyphens, and apostrophes'): Checks that the city parameter contains only letters, spaces, hyphens, and apostrophes. This regex allows for a broad range of city names. This will make more validation and error handling.